### PR TITLE
Fix ingress template

### DIFF
--- a/hack/test-values/expected-results/ingress.yaml
+++ b/hack/test-values/expected-results/ingress.yaml
@@ -1,0 +1,143 @@
+---
+# Source: app/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # property-like keys; each key maps to a simple value
+  test.conf: |-
+    hello
+---
+# Source: app/templates/pvc.yaml
+# Copyright 2022 github.com/cetic
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1G
+---
+# Source: app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-app-svc-web
+  labels:
+    app.kubernetes.io/name: release-name-app-svc-web
+    helm.sh/chart: app-0.14.1
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: release-name
+  ports:
+    - name: http
+      port: 8000
+      protocol: TCP
+      targetPort: 8000
+---
+# Source: app/templates/deployment.yaml
+# Copyright 2022 github.com/cetic
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-app
+  labels:
+    app.kubernetes.io/name: app
+    helm.sh/chart: app-0.14.1
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app
+        app.kubernetes.io/instance: release-name
+    spec:      
+      automountServiceAccountToken: false
+      hostNetwork: false
+      containers:
+        - name: app
+          image: "myrepo.com/my-image:v1.2.3"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+          - name: "VAR1"
+            value: "value1"
+          volumeMounts:
+            - mountPath: /test
+              name: test-volume
+            - mountPath: /data
+              name: my-data-volume
+              subPath:  data
+            - mountPath: /var/lib/logs
+              name: my-data-volume
+              subPath:  logs
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+      volumes:
+        - name: test-volume
+          configMap:
+            name: test
+        - name: my-data-volume
+          persistentVolumeClaim:
+            claimName: my-data
+---
+# Source: app/templates/ingress.yaml
+# Copyright 2022 github.com/cetic
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: release-name-app
+  labels:
+    app.kubernetes.io/name: release-name-app
+    helm.sh/chart: app-0.14.1
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+    - host: "chart-example.local"
+      http:
+        paths:
+          - path: /
+            pathType: 
+            backend:
+              service:
+                name: release-name-app-svc-web
+                port: 
+                  number: 8000
+---
+# Source: app/templates/configmap.yaml
+# Copyright 2022 github.com/cetic
+---
+# Source: app/templates/rbac.yaml
+# Copyright 2022 github.com/cetic
+---
+# Source: app/templates/secret-docker.yaml
+# Copyright 2022 github.com/cetic
+---
+# Source: app/templates/service.yaml
+# Copyright 2022 github.com/cetic

--- a/hack/test-values/expected-results/ingress.yaml
+++ b/hack/test-values/expected-results/ingress.yaml
@@ -1,27 +1,4 @@
 ---
-# Source: app/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test
-data:
-  # property-like keys; each key maps to a simple value
-  test.conf: |-
-    hello
----
-# Source: app/templates/pvc.yaml
-# Copyright 2022 github.com/cetic
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: my-data
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1G
----
 # Source: app/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -79,15 +56,6 @@ spec:
           env:
           - name: "VAR1"
             value: "value1"
-          volumeMounts:
-            - mountPath: /test
-              name: test-volume
-            - mountPath: /data
-              name: my-data-volume
-              subPath:  data
-            - mountPath: /var/lib/logs
-              name: my-data-volume
-              subPath:  logs
           resources:
             limits:
               cpu: 100m
@@ -95,13 +63,6 @@ spec:
             requests:
               cpu: 100m
               memory: 200Mi
-      volumes:
-        - name: test-volume
-          configMap:
-            name: test
-        - name: my-data-volume
-          persistentVolumeClaim:
-            claimName: my-data
 ---
 # Source: app/templates/ingress.yaml
 # Copyright 2022 github.com/cetic
@@ -131,6 +92,9 @@ spec:
                   number: 8000
 ---
 # Source: app/templates/configmap.yaml
+# Copyright 2022 github.com/cetic
+---
+# Source: app/templates/pvc.yaml
 # Copyright 2022 github.com/cetic
 ---
 # Source: app/templates/rbac.yaml

--- a/hack/test-values/ingress.yaml
+++ b/hack/test-values/ingress.yaml
@@ -65,27 +65,7 @@ updateStrategy: {}
   # type: Recreate
 
 volumes:
-  enabled: true
-  pvc:
-    enabled: true
-    existingClaim: null
-    name: my-data
-    mountPath: ""
-    subPaths:
-    - mountPath: /data
-      subPath: data
-    - mountPath: /var/lib/logs
-      subPath: logs
-    size: 1G
-    class:
-    accessModes:
-      - ReadWriteOnce
-  configMaps:
-    - name: test
-      mountPath: /test
-      data:
-        test.conf: |
-          hello
+  enabled: false
 
 ingress:
   enabled: true

--- a/hack/test-values/ingress.yaml
+++ b/hack/test-values/ingress.yaml
@@ -1,0 +1,117 @@
+global:
+  replicaCount: 1
+  environment: {}
+   # list of key: value
+   # GLOBAL1: value
+
+deployment: true
+hostNetwork: false
+
+image:
+  repository: "myrepo.com/my-image"
+  tag: "v1.2.3"
+  pullPolicy: IfNotPresent
+
+  #replicaCount: 1
+
+# command: ["/bin/sh","-c"]
+# args: ["echo 'consuming a message'; sleep 5"]
+
+nameOverride: ""
+fullnameOverride: ""
+
+#serviceAccount: microservice-sa
+createServiceAccount: false
+rbac: false
+
+# Annotation for the Deployment
+annotations: {}
+
+# List of services
+services:
+  - name: web
+    type: ClusterIP
+    annotations: {}
+    specs:
+    - port: 8000
+      targetPort: 8000
+      name: http
+
+environment:
+  VAR1: value1
+
+#Probes
+liveness:
+  enabled: false
+  path: /alive
+  port: 8001
+  initialDelaySeconds: 3
+  periodSeconds: 3
+readiness:
+  enabled: false
+  path: /ready
+  port: 8001
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 3
+
+
+updateStrategy: {}
+  ## for stateless apps, Default
+  # type: RollingUpdate
+  # rollingUpdate: {}
+
+  ## for stateful apps: 
+  # type: Recreate
+
+volumes:
+  enabled: true
+  pvc:
+    enabled: true
+    existingClaim: null
+    name: my-data
+    mountPath: ""
+    subPaths:
+    - mountPath: /data
+      subPath: data
+    - mountPath: /var/lib/logs
+      subPath: logs
+    size: 1G
+    class:
+    accessModes:
+      - ReadWriteOnce
+  configMaps:
+    - name: test
+      mountPath: /test
+      data:
+        test.conf: |
+          hello
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      servicePort: 8000
+      serviceName: web
+      path: /
+  tls: []
+  pathType: Prefix
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 200Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 # Copyright 2022 github.com/cetic
-{{- $root:= . }}
+{{ $root:= . }}
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
The first line of the ingress template, which contains the apiVersion, was sticking to the copy right comment at the top